### PR TITLE
Compatibilidad con certificados y llaves en forma de string

### DIFF
--- a/src/SecurityHelper.php
+++ b/src/SecurityHelper.php
@@ -5,9 +5,14 @@ class SecurityHelper
 {
     public static function getCommonName($X509Cert)
     {
-        $handler = fopen($X509Cert, "r");
-        $cert = fread($handler, 8192);
-        fclose($handler);
+        if (is_file($X509Cert)) {
+            $handler = fopen($X509Cert, "r");
+            $cert = fread($handler, 8192);
+            fclose($handler);
+        } else {
+            $cert = $X509Cert;
+        }
+
         $cert_as_array = openssl_x509_parse($cert);
         return $cert_as_array['subject']['CN'];
     }

--- a/src/TransbankSoap.php
+++ b/src/TransbankSoap.php
@@ -76,7 +76,7 @@ class TransbankSoap extends SoapClient
         $objWSSE = new WSSESoap($doc);
         $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' =>
             'private'));
-        $objKey->loadKey($this->getPrivateKey(), true);
+        $objKey->loadKey($this->getPrivateKey());
         $options = array("insertBefore" => true);
         $objWSSE->signSoapDoc($objKey, $options);
         $objWSSE->addIssuerSerial($this->getCertificate());

--- a/src/wss/soap-validation.php
+++ b/src/wss/soap-validation.php
@@ -130,11 +130,15 @@ class SoapValidation
 
         do {
             if (empty($objKey->key)) {
-                $handler = fopen($this->certServerPath, "r");
-                $x509cert = fread($handler, 8192);
-                fclose($handler);
+                if (is_file($this->certServerPath)) {
+                    $handler = fopen($this->certServerPath, "r");
+                    $x509cert = fread($handler, 8192);
+                    fclose($handler);
+                } else {
+                    $x509cert = $this->certServerPath;
+                }
 
-                $objKey->loadKey($x509cert, false, true);
+                $objKey->loadKey($x509cert, true);
                 break;
 
                 throw new Exception("Error loading key to handle Signature");

--- a/src/wss/soap-wsse.php
+++ b/src/wss/soap-wsse.php
@@ -468,12 +468,10 @@ class WSSESoap
     public function decryptSoapDoc($doc, $options)
     {
         $privKey = null;
-        $privKey_isFile = false;
         $privKey_isCert = false;
 
         if (is_array($options)) {
             $privKey = (!empty($options["keys"]["private"]["key"]) ? $options["keys"]["private"]["key"] : null);
-            $privKey_isFile = (!empty($options["keys"]["private"]["isFile"]) ? true : false);
             $privKey_isCert = (!empty($options["keys"]["private"]["isCert"]) ? true : false);
         }
 
@@ -498,7 +496,7 @@ class WSSESoap
             XMLSecEnc::staticLocateKeyInfo($objKey, $node);
             if ($objKey && $objKey->isEncrypted) {
                 $objencKey = $objKey->encryptedCtx;
-                $objKey->loadKey($privKey, $privKey_isFile, $privKey_isCert);
+                $objKey->loadKey($privKey, $privKey_isCert);
                 $key = $objencKey->decryptKey($objKey);
                 $objKey->loadKey($key);
             }

--- a/src/wss/xmlseclibs.php
+++ b/src/wss/xmlseclibs.php
@@ -155,9 +155,13 @@ function canonical($tree, $element, $withcomments)
 
 function getIssuerName($X509Cert)
 {
-    $handler = fopen($X509Cert, "r");
-    $cert = fread($handler, 8192);
-    fclose($handler);
+    if (is_file($X509Cert)) {
+        $handler = fopen($X509Cert, "r");
+        $cert = fread($handler, 8192);
+        fclose($handler);
+    } else {
+        $cert = $X509Cert;
+    }
     $cert_as_array = openssl_x509_parse($cert);
     $name = $cert_as_array['name'];
     $name = str_replace("/", ",", $name);
@@ -174,9 +178,13 @@ function getIssuerName($X509Cert)
 
 function getSerialNumber($X509Cert)
 {
-    $handler = fopen($X509Cert, "r");
-    $cert = fread($handler, 8192);
-    fclose($handler);
+    if (is_file($X509Cert)) {
+        $handler = fopen($X509Cert, "r");
+        $cert = fread($handler, 8192);
+        fclose($handler);
+    } else {
+        $cert = $X509Cert;
+    }
     $cert_as_array = openssl_x509_parse($cert);
     $serialNumber = $cert_as_array['serialNumber'];
     return $serialNumber;

--- a/src/wss/xmlseclibs.php
+++ b/src/wss/xmlseclibs.php
@@ -477,9 +477,9 @@ class XMLSecurityKey
      * @param bool $isCert
      * @throws Exception
      */
-    public function loadKey($key, $isFile = false, $isCert = false)
+    public function loadKey($key, $isCert = false)
     {
-        if ($isFile) {
+        if (is_file($key)) {
             $this->key = file_get_contents($key);
         } else {
             $this->key = $key;
@@ -2026,7 +2026,7 @@ class XMLSecEnc
                                     $x509cert = $x509certNodes->item(0)->textContent;
                                     $x509cert = str_replace(array("\r", "\n"), "", $x509cert);
                                     $x509cert = "-----BEGIN CERTIFICATE-----\n" . chunk_split($x509cert, 64, "\n") . "-----END CERTIFICATE-----\n";
-                                    $objBaseKey->loadKey($x509cert, false, true);
+                                    $objBaseKey->loadKey($x509cert, true);
                                 }
                             }
                             break;


### PR DESCRIPTION
Actualmente la clase ```CertificationBag``` solo acepta el _path_ de los certificados y llaves, sin embargo, existen casos en los cuales es preferible utilizar directamente el contenido de los archivos.
Me valí de la función ```is_file``` de PHP para comprobar si efectivamente son archivos o puede ser el contenido de los mismos.