### PR TITLE
Llamada correcta al comando publish

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -433,7 +433,7 @@ $providers = [
 ]
 ```
 Opcionalmente, puedes crear el archivo de configuración `config/webpay.php` usando este comando:
-`php artisan vendor:publish --provider=\Freshwork\Transbank\Laravel\WebpayServiceProvider`
+`php artisan vendor:publish --provider="Freshwork\Transbank\Laravel\WebpayServiceProvider"`
 
 ## Usando en Laravel
 La gracia de esta integración, en que puedes usar los servicios (webpay normal, patpass, one click, etc) usando el sistema de dependencias de Laravel. 


### PR DESCRIPTION
El cambio es necesario para correr el comando correctamente ya que no encontraba los recursos. Esta publicación es importante ya que permite incluir el archivo de configuración, de los certificados públicos y privados para transbank, en el proyecto que use este paquete. Si no se cambian, al momento de la redirección hacia el "response" de transbank, se comprobarían los datos de la transacción con unos certificados que no existen "app/certificados/client.key"; a menos que se cambien directamente en el paquete la cual, en mi opinión considero, que no es la idea. Agrego que, el paquete funciona perfectamente pero sin ese cambio no termina el flujo de transbank por lo antes mencionado.